### PR TITLE
package project with readme file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include readme.md

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 from os import path
 
 this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
+with open(path.join(this_directory, "readme.md"), encoding="utf-8") as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
pip install pingtop报错:

```
Looking in indexes: https://pypi.douban.com/simple
Collecting pingtop
  Downloading https://pypi.doubanio.com/packages/86/1c/5064bd238902f7ee693ab792af6de801b021dc3caa5e0d4d977fd1fd6561/pingtop-0.2.3.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-k736hmgl/pingtop/setup.py", line 7, in <module>
        with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-install-k736hmgl/pingtop/README.md'
```