### PR TITLE
Flexible host column resizing

### DIFF
--- a/pingtop.py
+++ b/pingtop.py
@@ -350,6 +350,8 @@ def multi_ping(host, packetsize, logto, log_level):
     logger.info(f"Hosts: {hosts}")
     worker_num = len(hosts)
     logger.info(f"Open ThreadPoolExecutor with max_workers={worker_num}.")
+    max_host_length = max([len(host) for host in hosts] + [9]) + 2
+    COLUMNS[0].width = max_host_length if max_host_length < 40 else 40
     tablebox = MainBox(
         packetsize,
         1000,


### PR DESCRIPTION
Determine the size of the host column based on the maximum host length. For hostnames that are longer than 16 characters.

Figured that hostnames longer than 40 characters may be unreasonable, or they may take up too much horizontal space.