### PR TITLE
Fix bug in receive_one_ping func

### DIFF
--- a/ping.py
+++ b/ping.py
@@ -150,8 +150,14 @@ def receive_one_ping(my_socket, id, timeout):
         received_packet, addr = my_socket.recvfrom(1024)
         icmpHeader = received_packet[20:28]
         type, code, checksum, packet_id, sequence = struct.unpack("bbHHh", icmpHeader)
-        if packet_id == id:
-            bytes = struct.calcsize("d")
+        bytes = struct.calcsize("d")
+
+        if my_socket.type == socket.SocketKind.SOCK_DGRAM:
+            # id filled by kernel, but packet is guaranteed the one we requested.
+            # Also, no IP header, so offset is 8.
+            time_sent = struct.unpack("d", received_packet[8 : 8 + bytes])[0]
+            return time_received - time_sent
+        elif packet_id == id:
             time_sent = struct.unpack("d", received_packet[28 : 28 + bytes])[0]
             return time_received - time_sent
 


### PR DESCRIPTION
There is a bug in `receive_one_ping` function now and this PR intends to fix it

When we are using `SOCK_DGRAM` to send packets, the `packet_id` from the reply will be filled by the kernel and it could be different(leading to an `all packet lost problem`)
![image](https://user-images.githubusercontent.com/10581586/56809221-f2712e00-6865-11e9-8c23-eb6ab69cf595.png)

For packets sent through `SOCK_DGRAM`, we don't need to check `packet_id`.

https://github.com/laixintao/pingtop/issues/21#issuecomment-487041446-permalink