### PR TITLE
Refine details panel trend rendering

### DIFF
--- a/src/pingtop/app.tcss
+++ b/src/pingtop/app.tcss
@@ -9,7 +9,7 @@ Screen {
 }
 
 #details-panel {
-    height: 13;
+    height: 15;
     border: round $accent;
     padding: 1 2;
     margin-top: 1;

--- a/src/pingtop/widgets/details_panel.py
+++ b/src/pingtop/widgets/details_panel.py
@@ -5,43 +5,24 @@ from typing import cast
 from rich.text import Text
 from textual.widgets import Static
 
-from pingtop.models import TIMEOUT_MARKER
-from pingtop.widgets.trend import render_trend_graph
+from pingtop.widgets.trend import render_detailed_trend_graph
 
 
 class DetailsPanel(Static):
     DEFAULT_MESSAGE = "Select a host to inspect live statistics."
+    COLUMN_GAP = 4
+    LEFT_COLUMN_MAX_WIDTH = 30
 
     def show_host(self, row: dict[str, object] | None) -> None:
         if row is None:
             self.update(self.DEFAULT_MESSAGE)
             return
         history = cast(list[float | None], row["history_ms"])
-        graph_width = self._graph_width()
-        details = Text(
-            "\n".join(
-                [
-                    f"Host:     {row['target']}",
-                    f"IP:       {row['resolved_ip'] or '-'}",
-                    f"State:    {row['state']}",
-                    f"Last RTT: {self._fmt(row['last_rtt_ms'])}",
-                    f"Min RTT:  {self._fmt(row['min_rtt_ms'])}",
-                    f"Avg RTT:  {self._fmt(row['avg_rtt_ms'])}",
-                    f"Max RTT:  {self._fmt(row['max_rtt_ms'])}",
-                    f"StdDev:   {self._fmt(row['stddev_ms'])}",
-                    f"Sent:     {row['seq']}",
-                    f"Lost:     {row['lost']} ({float(cast(float, row['loss_percent'])):.1f}%)",
-                    f"Error:    {row['last_error'] or '-'}",
-                    "",
-                    "Trend Graph",
-                    self._trend_scale(history),
-                    "oldest -> newest",
-                ]
-            )
-            + "\n"
-        )
-        details.append_text(render_trend_graph(history, width=graph_width))
-        self.update(details)
+        left_lines = self._left_column_lines(row)
+        left_width = self._left_column_width(left_lines)
+        graph_width = self._graph_width(left_width)
+        right_lines = render_detailed_trend_graph(history, width=graph_width)
+        self.update(self._compose_columns(left_lines, right_lines, left_width))
 
     @staticmethod
     def _fmt(value: object) -> str:
@@ -49,14 +30,51 @@ class DetailsPanel(Static):
             return "-"
         return f"{float(cast(float, value)):.1f} ms"
 
-    def _graph_width(self) -> int:
+    def _graph_width(self, left_width: int) -> int:
         if self.size.width <= 0:
             return 32
-        return max(12, min(48, self.size.width - 4))
+        available = self.size.width - left_width - self.COLUMN_GAP - 6
+        return max(16, min(72, available))
+
+    def _left_column_lines(self, row: dict[str, object]) -> list[str]:
+        return [
+            f"Host: {row['target']}",
+            f"IP: {row['resolved_ip'] or '-'}",
+            f"State: {row['state']}",
+            f"Last RTT: {self._fmt(row['last_rtt_ms'])}",
+            f"Min RTT: {self._fmt(row['min_rtt_ms'])}",
+            f"Avg RTT: {self._fmt(row['avg_rtt_ms'])}",
+            f"Max RTT: {self._fmt(row['max_rtt_ms'])}",
+            f"StdDev: {self._fmt(row['stddev_ms'])}",
+            f"Sent: {row['seq']}",
+            f"Loss: {row['lost']} ({float(cast(float, row['loss_percent'])):.1f}%)",
+            f"Error: {self._truncate(str(row['last_error'] or '-'))}",
+        ]
+
+    def _left_column_width(self, lines: list[str]) -> int:
+        if not lines:
+            return 0
+        return min(self.LEFT_COLUMN_MAX_WIDTH, max(len(line) for line in lines))
+
+    def _compose_columns(
+        self, left_lines: list[str], right_lines: list[Text], left_width: int
+    ) -> Text:
+        details = Text()
+        line_count = max(len(left_lines), len(right_lines))
+        for index in range(line_count):
+            if index:
+                details.append("\n")
+            left_line = left_lines[index] if index < len(left_lines) else ""
+            details.append(self._truncate(left_line, left_width).ljust(left_width))
+            details.append(" " * self.COLUMN_GAP)
+            if index < len(right_lines):
+                details.append_text(right_lines[index])
+        return details
 
     @staticmethod
-    def _trend_scale(history: list[float | None]) -> str:
-        samples = [sample for sample in history if sample is not None]
-        if not samples:
-            return "timeouts only"
-        return f"low {min(samples):.1f} ms / high {max(samples):.1f} ms / timeout {TIMEOUT_MARKER}"
+    def _truncate(value: str, width: int | None = None) -> str:
+        if width is None or width <= 0 or len(value) <= width:
+            return value
+        if width <= 3:
+            return value[:width]
+        return f"{value[: width - 3]}..."

--- a/src/pingtop/widgets/trend.py
+++ b/src/pingtop/widgets/trend.py
@@ -19,6 +19,7 @@ TREND_STYLES = (
 )
 TIMEOUT_STYLE = "bold #ef4444"
 DETAIL_GRAPH_EMPTY_STYLE = "#4b5563"
+DETAIL_GRAPH_AXIS_STYLE = "#9ca3af"
 
 
 def render_trend(history: Sequence[float | None] | None, *, width: int | None = None) -> Text:
@@ -73,3 +74,69 @@ def render_trend_graph(
             else:
                 graph.append("·", style=DETAIL_GRAPH_EMPTY_STYLE)
     return graph
+
+
+def render_detailed_trend_graph(
+    history: Sequence[float | None] | None,
+    *,
+    width: int | None = None,
+    height: int = 6,
+) -> list[Text]:
+    header = Text("RTT Graph", style="bold")
+    if not history:
+        return [header, Text("waiting for samples", style=DETAIL_GRAPH_EMPTY_STYLE)]
+
+    cells = list(history)
+    if width is not None and width > 0:
+        cells = cells[-width:]
+    if not cells:
+        return [header, Text("waiting for samples", style=DETAIL_GRAPH_EMPTY_STYLE)]
+
+    samples = [sample for sample in cells if sample is not None]
+    if not samples:
+        timeout_line = Text("timeouts │ ", style=DETAIL_GRAPH_AXIS_STYLE)
+        timeout_line.append(TIMEOUT_MARKER * len(cells), style=TIMEOUT_STYLE)
+        return [
+            header,
+            timeout_line,
+            _render_graph_axis(len(cells), len("timeouts")),
+            Text(" " * (len("timeouts") + 3) + "oldest -> newest", style=DETAIL_GRAPH_AXIS_STYLE),
+        ]
+
+    low = min(samples)
+    high = max(samples)
+    avg = sum(samples) / len(samples)
+    span = max(high - low, 1.0)
+    label_width = max(len(f"{low:.1f}"), len(f"{high:.1f}"))
+    header.append(f"  {low:.1f}..{high:.1f} ms", style=DETAIL_GRAPH_AXIS_STYLE)
+    header.append(f"  avg {avg:.1f}", style=DETAIL_GRAPH_AXIS_STYLE)
+
+    lines = [header]
+    for level in range(height, 0, -1):
+        scale_value = low + (span * (level - 1) / max(height - 1, 1))
+        line = Text(f"{scale_value:>{label_width}.1f} │ ", style=DETAIL_GRAPH_AXIS_STYLE)
+        for sample in cells:
+            if sample is None:
+                line.append(TIMEOUT_MARKER, style=TIMEOUT_STYLE)
+                continue
+            sample_height = 1 + round(((sample - low) / span) * (height - 1))
+            bucket = min(
+                len(TREND_STYLES) - 1,
+                int(((sample - low) / span) * (len(TREND_STYLES) - 1)),
+            )
+            if sample_height >= level:
+                line.append("█", style=TREND_STYLES[bucket])
+            else:
+                line.append("·", style=DETAIL_GRAPH_EMPTY_STYLE)
+        lines.append(line)
+
+    lines.append(_render_graph_axis(len(cells), label_width))
+    lines.append(Text(" " * (label_width + 3) + "oldest -> newest", style=DETAIL_GRAPH_AXIS_STYLE))
+    return lines
+
+
+def _render_graph_axis(width: int, label_width: int) -> Text:
+    axis = Text(" " * label_width, style=DETAIL_GRAPH_AXIS_STYLE)
+    axis.append(" └", style=DETAIL_GRAPH_AXIS_STYLE)
+    axis.append("─" * width, style=DETAIL_GRAPH_AXIS_STYLE)
+    return axis

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -162,11 +162,12 @@ async def test_details_panel_defaults_open_on_large_window_and_closed_on_small_w
         assert details.has_class("hidden-panel")
         assert len(table.ordered_columns) == len(HostTable.COLUMN_PROFILES["narrow"])
         await pilot.press("i")
-        await pilot.pause(0.05)
+        await pilot.pause(0.15)
         assert not details.has_class("hidden-panel")
         details_render = details.render()
-        assert "Trend Graph" in details_render.plain
+        assert "RTT Graph" in details_render.plain
         assert "oldest -> newest" in details_render.plain
+        assert "Host:" in details_render.plain
         await pilot.press("q")
 
 

--- a/tests/test_trend.py
+++ b/tests/test_trend.py
@@ -4,9 +4,11 @@ from rich.text import Text
 
 from pingtop.models import TIMEOUT_MARKER, TREND_BLOCKS, build_trend
 from pingtop.widgets.trend import (
+    DETAIL_GRAPH_AXIS_STYLE,
     DETAIL_GRAPH_EMPTY_STYLE,
     TIMEOUT_STYLE,
     TREND_STYLES,
+    render_detailed_trend_graph,
     render_trend,
     render_trend_graph,
     render_trend_legend,
@@ -63,3 +65,17 @@ def test_render_trend_graph_builds_multiline_chart() -> None:
     assert TIMEOUT_MARKER in graph.plain
     assert any(span.style == TIMEOUT_STYLE for span in graph.spans)
     assert any(span.style == DETAIL_GRAPH_EMPTY_STYLE for span in graph.spans)
+
+
+def test_render_detailed_trend_graph_includes_scale_and_axis() -> None:
+    graph_lines = render_detailed_trend_graph([10.0, 15.0, 30.0, None], width=4, height=4)
+
+    assert graph_lines[0].plain.startswith("RTT Graph")
+    assert any("oldest -> newest" in line.plain for line in graph_lines)
+    assert any(TIMEOUT_MARKER in line.plain for line in graph_lines)
+    assert any("└" in line.plain for line in graph_lines)
+    assert any(
+        span.style == DETAIL_GRAPH_AXIS_STYLE
+        for line in graph_lines
+        for span in line.spans
+    )


### PR DESCRIPTION
## Summary
- Reworked the details panel into a two-column layout with host stats on the left and a more readable RTT graph on the right.
- Added a dedicated detailed trend graph renderer with axis labels, scale info, average RTT, and timeout handling.
- Increased the details panel height to fit the expanded layout.
- Updated tests to cover the new details panel text and detailed graph rendering.

## Testing
- `pytest tests/test_trend.py`
- `pytest tests/test_app.py`
- Not run: full test suite