### PR TITLE
Add colored session summaries on exit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Features
 --------
 
 - Monitor multiple hosts concurrently in a live Textual table
-- Keep BSD-style ping summary output on exit
+- Print a short colored summary on exit
 - Add, edit, delete, pause, and reset hosts during a session
 - Export final statistics as JSON or CSV
 - Keep a raw ICMP engine instead of shelling out to the system ``ping`` command
@@ -58,7 +58,7 @@ Options include:
 - ``-t, --timeout`` timeout in seconds
 - ``-s, --packet-size`` ICMP payload size in bytes
 - ``--hosts-file`` newline-delimited host list
-- ``--summary / --no-summary`` print BSD-style summary on exit
+- ``--summary / --no-summary`` print a short colored summary on exit
 - ``--export`` output path
 - ``--export-format [json|csv]`` export format override
 - ``--log-file`` log destination

--- a/src/pingtop/cli.py
+++ b/src/pingtop/cli.py
@@ -127,7 +127,7 @@ def main(
     snapshot = session.snapshot()
     exit_code = 0
     if summary:
-        click.echo(render_summary(snapshot))
+        click.echo(render_summary(snapshot, color=True), color=True)
     if export_path and resolved_export_format:
         try:
             export_snapshot(snapshot, export_path, resolved_export_format)

--- a/src/pingtop/summary.py
+++ b/src/pingtop/summary.py
@@ -2,36 +2,139 @@ from __future__ import annotations
 
 from typing import cast
 
+import click
+
 from pingtop.models import SessionSnapshot
 
+MAX_ISSUES = 5
 
-def render_summary(snapshot: SessionSnapshot) -> str:
-    blocks: list[str] = []
+
+def render_summary(
+    snapshot: SessionSnapshot,
+    *,
+    color: bool = False,
+    max_issues: int = MAX_ISSUES,
+) -> str:
+    style = _styler(color)
+    total_hosts = int(cast(int, snapshot.aggregates["total_hosts"]))
+    total_sent = int(cast(int, snapshot.aggregates["total_sent"]))
+    total_lost = int(cast(int, snapshot.aggregates["total_lost"]))
+    error_hosts = int(cast(int, snapshot.aggregates["error_hosts"]))
+    total_received = total_sent - total_lost
+    lossy_hosts = sum(
+        1
+        for host in snapshot.hosts
+        if int(cast(int, host["seq"])) > 0 and int(cast(int, host["lost"])) > 0
+    )
+    idle_hosts = sum(
+        1
+        for host in snapshot.hosts
+        if int(cast(int, host["seq"])) == 0 and not host["last_error"]
+    )
+
+    status_text, status_color = _status(snapshot)
+    parts = [
+        style(status_text, fg=status_color, bold=True),
+        f"{total_hosts} hosts",
+        f"tx {total_sent}",
+        f"rx {total_received}",
+        f"loss {style(f'{_loss_percent(total_lost, total_sent):.1f}%', fg=_loss_color(total_lost, total_sent), bold=True)}",
+    ]
+    if error_hosts:
+        parts.append(f"err {style(str(error_hosts), fg='red', bold=True)}")
+    if lossy_hosts:
+        parts.append(f"lossy {style(str(lossy_hosts), fg='yellow', bold=True)}")
+    if idle_hosts:
+        parts.append(f"idle {style(str(idle_hosts), fg='blue', bold=True)}")
+
+    lines = [" | ".join(parts)]
+    issue_lines = _issue_lines(snapshot, style, max_issues=max_issues)
+    lines.extend(issue_lines)
+    return "\n".join(lines)
+
+
+def _issue_lines(
+    snapshot: SessionSnapshot,
+    style,
+    *,
+    max_issues: int,
+) -> list[str]:
+    issues: list[tuple[tuple[object, ...], str]] = []
     for host in snapshot.hosts:
-        hostname = str(host["target"])
-        error = host["last_error"]
-        if host["seq"] == 0 and error and error != "timeout":
-            blocks.append(
-                f"--- {hostname} ping statistics ---\n"
-                f"ping: cannot resolve {hostname}: {error}"
-            )
-            continue
+        target = str(host["target"])
         seq = int(cast(int, host["seq"]))
         lost = int(cast(int, host["lost"]))
-        received = seq - lost
-        packet_lost = (lost / seq * 100) if seq else 0.0
-        summary = (
-            f"--- {hostname} ping statistics ---\n"
-            f"{seq} packets transmitted, {received} packets received, "
-            f"{packet_lost:.1f}% packet loss"
-        )
-        if host["min_rtt_ms"] is not None:
-            summary += (
-                "\nround-trip min/avg/max/stddev = "
-                f"{float(cast(float, host['min_rtt_ms'])):.2f}/"
-                f"{float(cast(float, host['avg_rtt_ms'])):.2f}/"
-                f"{float(cast(float, host['max_rtt_ms'])):.2f}/"
-                f"{float(cast(float, host['stddev_ms'] or 0.0)):.2f} ms"
+        error = host["last_error"]
+        avg_rtt_ms = host["avg_rtt_ms"]
+
+        if seq == 0 and error and error != "timeout":
+            issues.append(
+                (
+                    (0, target.lower()),
+                    f"{style('ERR', fg='red', bold=True)} {target} {error}",
+                )
             )
-        blocks.append(summary)
-    return "\n\n".join(blocks)
+            continue
+
+        if seq == 0 or lost == 0:
+            continue
+
+        loss_percent = _loss_percent(lost, seq)
+        label = "DOWN" if lost == seq else "LOSS"
+        label_color = "red" if lost == seq else "yellow"
+        detail = f"{loss_percent:.1f}% loss ({lost}/{seq})"
+        if avg_rtt_ms is not None:
+            detail += f", avg {float(cast(float, avg_rtt_ms)):.1f} ms"
+        issues.append(
+            (
+                (1 if lost == seq else 2, -loss_percent, target.lower()),
+                f"{style(label, fg=label_color, bold=True)} {target} {detail}",
+            )
+        )
+
+    issues.sort(key=lambda item: item[0])
+    visible = [line for _, line in issues[:max_issues]]
+    if len(issues) > max_issues:
+        visible.append(
+            f"{style('MORE', fg='cyan', bold=True)} +{len(issues) - max_issues} more issues"
+        )
+    return visible
+
+
+def _status(snapshot: SessionSnapshot) -> tuple[str, str]:
+    has_error = any(
+        int(cast(int, host["seq"])) == 0 and host["last_error"] and host["last_error"] != "timeout"
+        for host in snapshot.hosts
+    )
+    has_down = any(
+        int(cast(int, host["seq"])) > 0 and int(cast(int, host["lost"])) == int(cast(int, host["seq"]))
+        for host in snapshot.hosts
+    )
+    has_loss = int(cast(int, snapshot.aggregates["total_lost"])) > 0
+    if has_error or has_down:
+        return "ERR", "red"
+    if has_loss:
+        return "WARN", "yellow"
+    return "OK", "green"
+
+
+def _loss_percent(lost: int, seq: int) -> float:
+    return (lost / seq * 100) if seq else 0.0
+
+
+def _loss_color(lost: int, seq: int) -> str:
+    loss_percent = _loss_percent(lost, seq)
+    if loss_percent >= 100.0 and seq > 0:
+        return "red"
+    if loss_percent > 0.0:
+        return "yellow"
+    return "green"
+
+
+def _styler(color: bool):
+    def apply(text: str, **styles: object) -> str:
+        if not color:
+            return text
+        return click.style(text, **styles)
+
+    return apply

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -15,8 +15,30 @@ def test_render_summary_success_and_error() -> None:
 
     summary = render_summary(session.snapshot())
 
-    assert "--- 1.1.1.1 ping statistics ---" in summary
-    assert "2 packets transmitted, 1 packets received, 50.0% packet loss" in summary
-    assert "round-trip min/avg/max/stddev = 10.00/10.00/10.00/0.00 ms" in summary
-    assert "ping: cannot resolve bad-host: Unknown host" in summary
+    assert summary.splitlines()[0] == "ERR | 2 hosts | tx 2 | rx 1 | loss 50.0% | err 1 | lossy 1"
+    assert "ERR bad-host Unknown host" in summary
+    assert "LOSS 1.1.1.1 50.0% loss (1/2), avg 10.0 ms" in summary
 
+
+def test_render_summary_stays_short_for_healthy_hosts() -> None:
+    session = PingSession(SessionConfig(), ["1.1.1.1", "8.8.8.8"])
+    for host_id, ip in zip(session.hosts, ["1.1.1.1", "8.8.8.8"], strict=True):
+        session.apply_result(host_id, PingResult(success=True, rtt_ms=10.0, resolved_ip=ip))
+
+    summary = render_summary(session.snapshot())
+
+    assert summary == "OK | 2 hosts | tx 2 | rx 2 | loss 0.0%"
+
+
+def test_render_summary_limits_issue_lines() -> None:
+    session = PingSession(
+        SessionConfig(),
+        ["bad-1", "bad-2", "bad-3", "bad-4", "bad-5", "bad-6", "bad-7"],
+    )
+    for host_id in session.hosts:
+        session.apply_result(host_id, PingResult(success=False, error_message="Unknown host"))
+
+    summary = render_summary(session.snapshot(), max_issues=5)
+
+    assert summary.count("\n") == 6
+    assert "MORE +2 more issues" in summary


### PR DESCRIPTION
## Summary
- Replace the old BSD-style exit summary with a shorter colored session summary.
- Show overall session status plus host counts, transmit/receive totals, loss, and optional error/lossy/idle indicators.
- Add issue-line rendering for failed and lossy hosts, capped to a configurable maximum with a `MORE` overflow line.
- Update CLI exit output to emit colored summary text and refresh README wording.
- Expand summary tests to cover healthy, error, and overflow cases.

## Testing
- `pytest tests/test_summary.py`
- Verified summary output is a single-line healthy summary when all hosts succeed.
- Verified error and loss cases render colored issue lines and the overflow notice.
- Not run: full test suite.