### PR TITLE
Implement a few gui tweaks to the details panel so that it looks better on small width terminals

### DIFF
--- a/src/pingtop/models.py
+++ b/src/pingtop/models.py
@@ -7,7 +7,7 @@ from statistics import stdev
 from typing import Protocol
 
 HostId = str
-MAX_HISTORY = 60
+MAX_HISTORY = 64
 TREND_BLOCKS = "▁▂▃▄▅▆▇█"
 TIMEOUT_MARKER = "╳"
 

--- a/src/pingtop/widgets/details_panel.py
+++ b/src/pingtop/widgets/details_panel.py
@@ -4,6 +4,7 @@ from typing import cast
 
 from rich.text import Text
 from textual.widgets import Static
+import pingtop.models
 
 from pingtop.widgets.trend import render_detailed_trend_graph
 
@@ -33,8 +34,8 @@ class DetailsPanel(Static):
     def _graph_width(self, left_width: int) -> int:
         if self.size.width <= 0:
             return 32
-        available = self.size.width - left_width - self.COLUMN_GAP - 6
-        return max(16, min(72, available))
+        available = self.size.width - left_width - self.COLUMN_GAP - 8
+        return max(16, min(pingtop.models.MAX_HISTORY, available))
 
     def _left_column_lines(self, row: dict[str, object]) -> list[str]:
         return [

--- a/src/pingtop/widgets/details_panel.py
+++ b/src/pingtop/widgets/details_panel.py
@@ -38,7 +38,7 @@ class DetailsPanel(Static):
         return max(16, min(pingtop.models.MAX_HISTORY, available))
 
     def _left_column_lines(self, row: dict[str, object]) -> list[str]:
-        return [
+        lines = [
             f"Host: {row['target']}",
             f"IP: {row['resolved_ip'] or '-'}",
             f"State: {row['state']}",
@@ -49,8 +49,13 @@ class DetailsPanel(Static):
             f"StdDev: {self._fmt(row['stddev_ms'])}",
             f"Sent: {row['seq']}",
             f"Loss: {row['lost']} ({float(cast(float, row['loss_percent'])):.1f}%)",
-            f"Error: {self._truncate(str(row['last_error'] or '-'))}",
         ]
+
+        last_err = row.get('last_error')
+        if last_err not in (None, '', b''):
+            lines.append(f"Error: {self._truncate(str(last_err))}")
+
+        return lines
 
     def _left_column_width(self, lines: list[str]) -> int:
         if not lines:

--- a/src/pingtop/widgets/trend.py
+++ b/src/pingtop/widgets/trend.py
@@ -125,9 +125,11 @@ def render_detailed_trend_graph(
                 line.append("█", style=TREND_STYLES[bucket])
             else:
                 line.append("·", style=DETAIL_GRAPH_EMPTY_STYLE)
+        for _ in range(width - len(cells)):
+             line.append("·", style=DETAIL_GRAPH_EMPTY_STYLE)
         lines.append(line)
 
-    lines.append(_render_graph_axis(len(cells), label_width))
+    lines.append(_render_graph_axis(width, label_width))
     return lines
 
 

--- a/src/pingtop/widgets/trend.py
+++ b/src/pingtop/widgets/trend.py
@@ -105,11 +105,8 @@ def render_detailed_trend_graph(
 
     low = min(samples)
     high = max(samples)
-    avg = sum(samples) / len(samples)
     span = max(high - low, 1.0)
     label_width = max(len(f"{low:.1f}"), len(f"{high:.1f}"))
-    header.append(f"  {low:.1f}..{high:.1f} ms", style=DETAIL_GRAPH_AXIS_STYLE)
-    header.append(f"  avg {avg:.1f}", style=DETAIL_GRAPH_AXIS_STYLE)
 
     lines = [header]
     for level in range(height, 0, -1):
@@ -131,7 +128,6 @@ def render_detailed_trend_graph(
         lines.append(line)
 
     lines.append(_render_graph_axis(len(cells), label_width))
-    lines.append(Text(" " * (label_width + 3) + "oldest -> newest", style=DETAIL_GRAPH_AXIS_STYLE))
     return lines
 
 


### PR DESCRIPTION
- Sets MAX_HISTORY to 64 so that it is a power of 2
- Tweaks graph width calculation to prevent it from wrapping (56x30 terminal size for the below screens):
Before:
 
<img width="487" height="571" alt="before" src="https://github.com/user-attachments/assets/56353cbe-4c29-4967-9a85-2ca5651053dd" />

After:

<img width="488" height="568" alt="obraz" src="https://github.com/user-attachments/assets/c968fca1-cfd0-479b-a843-2281804d8873" />

- Removes redundant information from the details panel to clean it up a bit
- Hides the Error line in the left panel unless there actually is an error
- Makes the whole graph render even when there aren't enough samples to cover the whole width