### PR TITLE
Fix hidden error when SOCK_DGRAM approach fails

### DIFF
--- a/src/pingtop/engine/icmp.py
+++ b/src/pingtop/engine/icmp.py
@@ -133,6 +133,7 @@ class IcmpEngine:
         icmp_proto = socket.getprotobyname("icmp")
         packet_id = None
         RTT = None
+        sock = None
         try:
             try:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_RAW, icmp_proto)
@@ -152,7 +153,8 @@ class IcmpEngine:
         except OSError as exc:
             return PingResult(success=False, resolved_ip=resolved_ip, error_message=str(exc))
         finally:
-            sock.close()
+            if sock is not None:
+                sock.close()
 
         if RTT is None:
             return PingResult(success=False, resolved_ip=resolved_ip)


### PR DESCRIPTION
If both the root only and SOCK_DGRAM approaches failed the sock variable was not defined causing an error inside of the finally block on the sock.close() call. As the exception was bubbled up it caused the whole async loop to fail not only causing the app to not retry but also not show the error as the loop would exit before post_message is be called.