### PR TITLE
Improve timeout graph and fix graph resize on details panel open

### DIFF
--- a/src/pingtop/app.tcss
+++ b/src/pingtop/app.tcss
@@ -1,5 +1,6 @@
 Screen {
     layout: vertical;
+    layers: background default
 }
 
 #host-table {
@@ -15,8 +16,12 @@ Screen {
     margin-top: 1;
 }
 
+/* TODO: less hacky way to make the panel not affect content height? */
 #details-panel.hidden-panel {
-    display: none;
+    layer: background;
+    max-height: 0;
+    padding: 0 0 0 0;
+    margin: 0 0 0 0;
 }
 
 #status-strip {

--- a/src/pingtop/models.py
+++ b/src/pingtop/models.py
@@ -7,7 +7,7 @@ from statistics import stdev
 from typing import Protocol
 
 HostId = str
-MAX_HISTORY = 64
+MAX_HISTORY = 256
 TREND_BLOCKS = "▁▂▃▄▅▆▇█"
 TIMEOUT_MARKER = "╳"
 

--- a/src/pingtop/widgets/details_panel.py
+++ b/src/pingtop/widgets/details_panel.py
@@ -33,7 +33,7 @@ class DetailsPanel(Static):
     def _graph_width(self, left_width: int) -> int:
         if self.size.width <= 0:
             return 32
-        available = self.size.width // 3 * 3 - left_width - self.COLUMN_GAP - 8
+        available = self.size.width // 3 * 3 - left_width - self.COLUMN_GAP - 6
         return max(8, min(pingtop.models.MAX_HISTORY, available))
 
     def _left_column_lines(self, row: dict[str, object]) -> list[str]:

--- a/src/pingtop/widgets/details_panel.py
+++ b/src/pingtop/widgets/details_panel.py
@@ -33,8 +33,8 @@ class DetailsPanel(Static):
     def _graph_width(self, left_width: int) -> int:
         if self.size.width <= 0:
             return 32
-        available = self.size.width - left_width - self.COLUMN_GAP - 8
-        return max(16, min(pingtop.models.MAX_HISTORY, available))
+        available = self.size.width // 3 * 3 - left_width - self.COLUMN_GAP - 8
+        return max(8, min(pingtop.models.MAX_HISTORY, available))
 
     def _left_column_lines(self, row: dict[str, object]) -> list[str]:
         lines = [

--- a/src/pingtop/widgets/details_panel.py
+++ b/src/pingtop/widgets/details_panel.py
@@ -12,7 +12,6 @@ from pingtop.widgets.trend import render_detailed_trend_graph
 class DetailsPanel(Static):
     DEFAULT_MESSAGE = "Select a host to inspect live statistics."
     COLUMN_GAP = 4
-    LEFT_COLUMN_MAX_WIDTH = 30
 
     def show_host(self, row: dict[str, object] | None) -> None:
         if row is None:
@@ -60,7 +59,7 @@ class DetailsPanel(Static):
     def _left_column_width(self, lines: list[str]) -> int:
         if not lines:
             return 0
-        return min(self.LEFT_COLUMN_MAX_WIDTH, max(len(line) for line in lines))
+        return max(len(line) for line in lines)
 
     def _compose_columns(
         self, left_lines: list[str], right_lines: list[Text], left_width: int

--- a/src/pingtop/widgets/details_panel.py
+++ b/src/pingtop/widgets/details_panel.py
@@ -11,7 +11,7 @@ from pingtop.widgets.trend import render_detailed_trend_graph
 
 class DetailsPanel(Static):
     DEFAULT_MESSAGE = "Select a host to inspect live statistics."
-    COLUMN_GAP = 4
+    COLUMN_GAP = 2
 
     def show_host(self, row: dict[str, object] | None) -> None:
         if row is None:

--- a/src/pingtop/widgets/trend.py
+++ b/src/pingtop/widgets/trend.py
@@ -20,6 +20,11 @@ TREND_STYLES = (
 TIMEOUT_STYLE = "bold #ef4444"
 DETAIL_GRAPH_EMPTY_STYLE = "#4b5563"
 DETAIL_GRAPH_AXIS_STYLE = "#9ca3af"
+GRAPH_VERTICAL_LINE = "│"
+GRAPH_HORIZONTAL_LINE = "─"
+GRAPH_LEFT_BOTTOM_CORNER = " └"
+GRAPH_CELL_BUCKET = "█"
+GRAPH_CELL_EMPTY = "·"
 
 
 def render_trend(history: Sequence[float | None] | None, *, width: int | None = None) -> Text:
@@ -70,9 +75,9 @@ def render_trend_graph(
                 continue
             bucket_height = max(1, math.ceil(((bucket + 1) / total_buckets) * height))
             if bucket_height >= level:
-                graph.append("█", style=TREND_STYLES[bucket])
+                graph.append(GRAPH_CELL_BUCKET, style=TREND_STYLES[bucket])
             else:
-                graph.append("·", style=DETAIL_GRAPH_EMPTY_STYLE)
+                graph.append(GRAPH_CELL_EMPTY, style=DETAIL_GRAPH_EMPTY_STYLE)
     return graph
 
 
@@ -92,27 +97,29 @@ def render_detailed_trend_graph(
     if not cells:
         return [header, Text("waiting for samples", style=DETAIL_GRAPH_EMPTY_STYLE)]
 
+    effective_width = width if width is not None else len(cells)
     samples = [sample for sample in cells if sample is not None]
+    lines = [header]
+
     if not samples:
-        timeout_line = Text("timeouts │ ", style=DETAIL_GRAPH_AXIS_STYLE)
-        timeout_line.append(TIMEOUT_MARKER * len(cells), style=TIMEOUT_STYLE)
-        return [
-            header,
-            timeout_line,
-            _render_graph_axis(len(cells), len("timeouts")),
-            Text(" " * (len("timeouts") + 3) + "oldest -> newest", style=DETAIL_GRAPH_AXIS_STYLE),
-        ]
+        # Prefix with spaces to reduce graph snap on initial render if first few pings fail
+        # Assume scale value to be in format XX.X
+        prefix = " " * 5
+        line = Text(prefix + GRAPH_VERTICAL_LINE + " ", style=DETAIL_GRAPH_AXIS_STYLE)
+        line.append(TIMEOUT_MARKER * len(cells), style=TIMEOUT_STYLE)
+        line.append(GRAPH_CELL_EMPTY * (effective_width - len(cells)), style=DETAIL_GRAPH_EMPTY_STYLE)
+        lines += [line] * height
+        lines.append(_render_graph_axis(effective_width, len(prefix) -1))
+        return lines
 
     low = min(samples)
     high = max(samples)
     span = max(high - low, 1.0)
     label_width = max(len(f"{low:.1f}"), len(f"{high:.1f}"))
 
-    effective_width = width if width is not None else len(cells)
-    lines = [header]
     for level in range(height, 0, -1):
         scale_value = low + (span * (level - 1) / max(height - 1, 1))
-        line = Text(f"{scale_value:>{label_width}.1f} │ ", style=DETAIL_GRAPH_AXIS_STYLE)
+        line = Text(f"{scale_value:>{label_width}.1f} " + GRAPH_VERTICAL_LINE + " ", style=DETAIL_GRAPH_AXIS_STYLE)
         for sample in cells:
             if sample is None:
                 line.append(TIMEOUT_MARKER, style=TIMEOUT_STYLE)
@@ -123,11 +130,10 @@ def render_detailed_trend_graph(
                 int(((sample - low) / span) * (len(TREND_STYLES) - 1)),
             )
             if sample_height >= level:
-                line.append("█", style=TREND_STYLES[bucket])
+                line.append(GRAPH_CELL_BUCKET, style=TREND_STYLES[bucket])
             else:
-                line.append("·", style=DETAIL_GRAPH_EMPTY_STYLE)
-        for _ in range(effective_width - len(cells)):
-            line.append("·", style=DETAIL_GRAPH_EMPTY_STYLE)
+                line.append(GRAPH_CELL_EMPTY, style=DETAIL_GRAPH_EMPTY_STYLE)
+        line.append(GRAPH_CELL_EMPTY * (effective_width - len(cells)), style=DETAIL_GRAPH_EMPTY_STYLE)
         lines.append(line)
 
     lines.append(_render_graph_axis(effective_width, label_width))
@@ -136,6 +142,6 @@ def render_detailed_trend_graph(
 
 def _render_graph_axis(width: int, label_width: int) -> Text:
     axis = Text(" " * label_width, style=DETAIL_GRAPH_AXIS_STYLE)
-    axis.append(" └", style=DETAIL_GRAPH_AXIS_STYLE)
-    axis.append("─" * width, style=DETAIL_GRAPH_AXIS_STYLE)
+    axis.append(GRAPH_LEFT_BOTTOM_CORNER, style=DETAIL_GRAPH_AXIS_STYLE)
+    axis.append(GRAPH_HORIZONTAL_LINE * (width + 1), style=DETAIL_GRAPH_AXIS_STYLE)
     return axis


### PR DESCRIPTION
- Fixes graph resizing on initial opening of the details tab. This was caused by the details element not having the size attribute set before show_host was called. By making it hidden its size wasn't calculated during the layout tick when not visible; causing a fallback to the hard coded size of 32. The implemented solution keeps renders it on a background layer when not visible. Functionally, it should be the same.

### Before:
<img width="1574" height="562" alt="output30346" src="https://github.com/user-attachments/assets/abadaa8f-dcfc-42a1-a04e-c5960c9f4f43" />

### After:
<img width="1582" height="568" alt="output29954" src="https://github.com/user-attachments/assets/851d2c9e-d4ac-44bb-8a28-c02b415010db" />

- Improves the timeout graph display to be more similar to the actual RTT display, reducing snapping/flicker during the transition.

### Before:

<img width="1581" height="558" alt="obraz" src="https://github.com/user-attachments/assets/80015153-243e-46bf-82f6-9929632398a4" />

### After:

<img width="1590" height="560" alt="obraz" src="https://github.com/user-attachments/assets/6c4e3e41-3d1d-4b2f-8eda-46da6a215d0b" />
